### PR TITLE
[email-limit]

### DIFF
--- a/src/main/java/com/mealfit/MealfitApplication.java
+++ b/src/main/java/com/mealfit/MealfitApplication.java
@@ -6,10 +6,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class MealfitApplication {
 

--- a/src/main/java/com/mealfit/common/email/FindPasswordEmail.java
+++ b/src/main/java/com/mealfit/common/email/FindPasswordEmail.java
@@ -26,7 +26,7 @@ public class FindPasswordEmail implements SendingEmailStrategy {
                   .append("<p>아래 링크를 클릭하시면 비밀번호 변경 페이지로 이동합니다.</p>")
                   .append("<a href='")
                   .append(url)
-                  .append("/user/validate?username=")
+                  .append("/user/password?username=")
                   .append(username)
                   .append("&authKey=")
                   .append(authKey)

--- a/src/main/java/com/mealfit/common/email/VerifyEmail.java
+++ b/src/main/java/com/mealfit/common/email/VerifyEmail.java
@@ -3,13 +3,13 @@ package com.mealfit.common.email;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
-public class SignUpEmail implements SendingEmailStrategy {
+public class VerifyEmail implements SendingEmailStrategy {
 
     private final String url;
     private final String username;
     private final String authKey;
 
-    public SignUpEmail(String url, String username, String authKey) {
+    public VerifyEmail(String url, String username, String authKey) {
         this.url = url;
         this.username = username;
         this.authKey = authKey;
@@ -26,9 +26,9 @@ public class SignUpEmail implements SendingEmailStrategy {
                   .append("<p>아래 링크를 클릭하시면 이메일 인증이 완료됩니다.</p>")
                   .append("<a href='")
                   .append(url)
-                  .append("/user/validate?username=")
+                  .append("/user/verify?username=")
                   .append(username)
-                  .append("&authKey=")
+                  .append("&code=")
                   .append(authKey)
                   .append("' target='_blenk'>이메일 인증 확인</a>")
 

--- a/src/main/java/com/mealfit/exception/email/BadVerifyCodeException.java
+++ b/src/main/java/com/mealfit/exception/email/BadVerifyCodeException.java
@@ -1,0 +1,12 @@
+package com.mealfit.exception.email;
+
+import com.mealfit.exception.wrapper.ErrorCode;
+
+public class BadVerifyCodeException extends EmailException{
+
+    private static final ErrorCode errorCode = ErrorCode.BAD_VERIFY_CODE;
+
+    public BadVerifyCodeException(String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/mealfit/exception/email/EmailException.java
+++ b/src/main/java/com/mealfit/exception/email/EmailException.java
@@ -1,0 +1,11 @@
+package com.mealfit.exception.email;
+
+import com.mealfit.exception.ApplicationException;
+import com.mealfit.exception.wrapper.ErrorCode;
+
+public class EmailException extends ApplicationException {
+
+    protected EmailException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/mealfit/exception/email/EmailSendCountLimitException.java
+++ b/src/main/java/com/mealfit/exception/email/EmailSendCountLimitException.java
@@ -1,0 +1,12 @@
+package com.mealfit.exception.email;
+
+import com.mealfit.exception.wrapper.ErrorCode;
+
+public class EmailSendCountLimitException extends EmailException {
+
+    private static final ErrorCode errorCode = ErrorCode.LIMIT_EMAIL_SEND;
+
+    public EmailSendCountLimitException(String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/mealfit/exception/wrapper/ErrorCode.java
+++ b/src/main/java/com/mealfit/exception/wrapper/ErrorCode.java
@@ -25,6 +25,10 @@ public enum ErrorCode implements ErrorModel {
     RESOURCE_NOT_FOUND(HttpStatus.BAD_REQUEST, "C003", "Resource not found"),
     EXPIRED_CODE(HttpStatus.BAD_REQUEST, "C004", "Expired Code"),
 
+    // EMAIL
+    LIMIT_EMAIL_SEND(HttpStatus.BAD_REQUEST, "E001", "한계치 초과!"),
+    BAD_VERIFY_CODE(HttpStatus.BAD_GATEWAY, "E002", "잘못된 인증 코드"),
+
     // AWS
     AWS_ERROR(HttpStatus.BAD_REQUEST, "A001", "aws client error"),
 

--- a/src/main/java/com/mealfit/user/application/EmailService.java
+++ b/src/main/java/com/mealfit/user/application/EmailService.java
@@ -3,60 +3,98 @@ package com.mealfit.user.application;
 import com.mealfit.common.email.EmailUtil;
 import com.mealfit.common.email.FindPasswordEmail;
 import com.mealfit.common.email.FindUsernameEmail;
-import com.mealfit.common.email.SignUpEmail;
+import com.mealfit.common.email.VerifyEmail;
+import com.mealfit.exception.email.BadVerifyCodeException;
+import com.mealfit.exception.email.EmailSendCountLimitException;
+import com.mealfit.exception.user.NoUserException;
 import com.mealfit.user.application.dto.request.EmailAuthRequestDto;
-import com.mealfit.user.application.dto.request.SendEmailRequestDto;
-import com.mealfit.user.domain.email.EmailCertificationRepository;
+import com.mealfit.user.domain.EmailEvent;
+import com.mealfit.user.domain.User;
+import com.mealfit.user.domain.UserRepository;
+import com.mealfit.user.domain.UserStatus;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Service
 public class EmailService {
 
     private final EmailUtil emailUtil;
-    private final EmailCertificationRepository emailCertificationRepository;
+    private final UserRepository userRepository;
+    private final ConcurrentHashMap<String, Integer> limitStorage = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, String> verifyStorage = new ConcurrentHashMap<>();
 
-    public EmailService(EmailUtil emailUtil,
-          EmailCertificationRepository emailCertificationRepository) {
+    public EmailService(EmailUtil emailUtil, UserRepository userRepository) {
         this.emailUtil = emailUtil;
-        this.emailCertificationRepository = emailCertificationRepository;
+        this.userRepository = userRepository;
     }
 
-    public void sendEmail(SendEmailRequestDto dto) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
+    public void sendEmail(EmailEvent event) {
+        int sendingCountByUser = limitStorage.getOrDefault(event.getSendingEmail(), 0);
+
+        if (sendingCountByUser > 5) {
+            throw new EmailSendCountLimitException("하루에 이메일을 5건 이상 전송할 수 없습니다.");
+        }
+
+        limitStorage.put(event.getSendingEmail(), sendingCountByUser + 1);
+
         String authKey = UUID.randomUUID().toString();
 
-        switch (dto.getEmailType()) {
-            case VALID_NEW_ACCOUNT:
-                emailUtil.sendEmail(dto.getSendingEmail(),
-                      new SignUpEmail(dto.getRedirectUrl(), dto.getUsername(), authKey));
+        verifyStorage.put(event.getUsername(), event.getSendingEmail());
+        switch (event.getEmailType()) {
+            case VERIFY:
+                emailUtil.sendEmail(event.getSendingEmail(),
+                      new VerifyEmail(event.getRedirectUrl(), event.getUsername(), authKey));
                 return;
+
             case FIND_USERNAME:
-                emailUtil.sendEmail(dto.getSendingEmail(),
-                      new FindUsernameEmail(dto.getUsername()));
+                emailUtil.sendEmail(event.getSendingEmail(),
+                      new FindUsernameEmail(event.getUsername()));
                 return;
+
             case FIND_PASSWORD:
-                emailUtil.sendEmail(dto.getSendingEmail(),
-                      new FindPasswordEmail(dto.getRedirectUrl(), dto.getUsername(), authKey));
+                emailUtil.sendEmail(event.getSendingEmail(),
+                      new FindPasswordEmail(event.getRedirectUrl(), event.getUsername(), authKey));
                 return;
+
             default:
                 throw new IllegalArgumentException("잘못된 이메일 양식입니다.");
         }
     }
 
     @Transactional
-    public void authEmail(EmailAuthRequestDto dto) {
-//        User user = findByUsername(dto.getUsername());
-//
-//        if (!user.checkNotValid()) {
-//            throw new IllegalStateException("이미 인증을 완료했습니다.");
-//        }
-//
-//        if (!emailCertificationRepository.existsByUsernameAndAuthKey(dto.getUsername(),
-//              dto.getAuthKey())) {
-//            throw new IllegalArgumentException("잘못된 요청입니다. 이메일 전송을 다시 한번 요청하세요.");
-//        }
-//
-//        user.changeUserStatus(UserStatus.FIRST_LOGIN);
+    public void verifyEmail(EmailAuthRequestDto dto) {
+        String verifyKey = verifyStorage.getOrDefault(dto.getUsername(), null);
+
+        if (verifyKey == null) {
+            throw new IllegalArgumentException("이메일을 보내셨는지 확인해주세요!");
+        }
+
+        if (!verifyKey.equals(dto.getAuthKey())) {
+            throw new BadVerifyCodeException("잘못된 인증 이메일입니다.");
+        }
+
+        User user = userRepository.findByUsername(dto.getUsername())
+              .orElseThrow(() -> new NoUserException("잘못된 인증정보입니다."));
+
+        if (!user.isNotValid()) {
+            throw new IllegalStateException("이미 인증하셨습니다!");
+        }
+
+        verifyStorage.remove(dto.getUsername());
+
+        user.changeUserStatus(UserStatus.FIRST_LOGIN);
+    }
+
+    @Scheduled(cron = "0 0 0 * * * *")
+    public void clearLimitStorage() {
+        limitStorage.clear();
     }
 }

--- a/src/main/java/com/mealfit/user/domain/EmailEvent.java
+++ b/src/main/java/com/mealfit/user/domain/EmailEvent.java
@@ -1,27 +1,24 @@
-package com.mealfit.user.application.dto.request;
+package com.mealfit.user.domain;
 
+
+import com.mealfit.user.application.dto.request.SendEmailRequestDto.EmailType;
 import lombok.Getter;
+import lombok.ToString;
 
+@ToString
 @Getter
-public class SendEmailRequestDto {
+public class EmailEvent {
 
     private String username;
     private String redirectUrl;
     private String sendingEmail;
     private EmailType emailType;
 
-    public SendEmailRequestDto(String username, String redirectUrl, String sendingEmail,
+    public EmailEvent(String username, String redirectUrl, String sendingEmail,
           EmailType emailType) {
         this.username = username;
         this.redirectUrl = redirectUrl;
         this.sendingEmail = sendingEmail;
         this.emailType = emailType;
     }
-
-    public enum EmailType {
-        VERIFY,
-        FIND_USERNAME,
-        FIND_PASSWORD
-    }
-
 }

--- a/src/main/java/com/mealfit/user/presentation/UserController.java
+++ b/src/main/java/com/mealfit/user/presentation/UserController.java
@@ -120,12 +120,12 @@ public class UserController {
     /**
      * 이메일 인증
      */
-    @GetMapping("/validate")
-    public ResponseEntity<String> checkEmail(String username, String authKey) {
-        EmailAuthRequestDto requestDto = UserServiceDtoFactory.emailAuthRequestDto(username,
-              authKey);
+    @GetMapping("/verify")
+    public ResponseEntity<String> checkEmail(String username, String code) {
+        EmailAuthRequestDto requestDto = UserServiceDtoFactory
+              .emailAuthRequestDto(username, code);
 
-        emailService.authEmail(requestDto);
+        emailService.verifyEmail(requestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED)
               .body("이메일이 성공적으로 인증되었습니다.");


### PR DESCRIPTION
- 이메일 전송을 signup() 로직에서 한꺼번에 처리하는 것을 이벤트 소싱으로 변경
- 이메일 같은 경우 단발성으로 사용되기 때문에 굳이 DB에 저장이 필요 없어 보여 인메모리 저장소에 저장
   - Redis, ConcurrentHashMap 중 ConcurrentHashMap 선택 (이를 위해 굳이 Redis 증설까지 하고 싶지 않았음)